### PR TITLE
🎨 Refactor: Introduce AppStateService to Centralize App State and Streamline Environment Management

### DIFF
--- a/lib/core/services/app_state_service.dart
+++ b/lib/core/services/app_state_service.dart
@@ -1,0 +1,60 @@
+import 'dart:convert';
+
+import 'package:canaspad/core/services/auth_service.dart';
+import 'package:canaspad/core/services/secure_storage_service.dart';
+import 'package:canaspad/core/services/supabase_service.dart';
+import 'package:canaspad/features/environment/models/environment_model.dart';
+import 'package:canaspad/providers.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+class AppStateService extends StateNotifier<AsyncValue<EnvironmentModel?>> {
+  final AuthService _authService;
+  final SecureStorageService _secureStorageService;
+  final SupabaseService _supabaseService;
+
+  AppStateService(this._authService, this._secureStorageService, this._supabaseService) : super(const AsyncValue.loading()) {
+    initializeApp();
+  }
+
+  Future<void> initializeApp() async {
+    state = const AsyncValue.loading();
+    try {
+      await _supabaseService.fetchAllData();
+      final environment = await _secureStorageService.readEnvironment();
+      if (environment != null) {
+        await login(environment);
+      } else {
+        state = const AsyncValue.data(null);
+      }
+    } catch (e, stack) {
+      state = AsyncValue.error(e, stack);
+    }
+  }
+
+  Future<void> login(EnvironmentModel environment) async {
+    try {
+      await _authService.signIn(
+        environment.emailAddress ?? '',
+        environment.password ?? '',
+      );
+      state = AsyncValue.data(environment);
+    } catch (e, stack) {
+      state = AsyncValue.error(e, stack);
+    }
+  }
+
+  Future<void> changeEnvironment(EnvironmentModel newEnvironment) async {
+    await _secureStorageService.writeSecureData(
+      'envSettings',
+      jsonEncode([newEnvironment.toJson()]),
+    );
+    await login(newEnvironment);
+  }
+}
+
+final appStateServiceProvider = StateNotifierProvider<AppStateService, AsyncValue<EnvironmentModel?>>((ref) {
+  final authService = ref.watch(authServiceProvider);
+  final secureStorageService = ref.watch(secureStorageServiceProvider);
+  final supabaseService = ref.watch(supabaseServiceProvider);
+  return AppStateService(authService, secureStorageService, supabaseService);
+});

--- a/lib/core/services/auth_service.dart
+++ b/lib/core/services/auth_service.dart
@@ -12,6 +12,7 @@ class SupabaseAuthService implements AuthService {
 
   Future<void> signIn(String email, String password) async {
     try {
+      print('Signing in with email: $email');
       await _client.auth.signInWithPassword(
         email: email,
         password: password,

--- a/lib/core/services/data_refresh_service.dart
+++ b/lib/core/services/data_refresh_service.dart
@@ -23,7 +23,7 @@ class DataRefreshService extends StateNotifier<void> {
     await refreshData();
 
     // 関連するViewModelの更新
-    _ref.read(numberDataViewModelProvider.notifier).loadNumericData();
+    _ref.read(numericDataViewModelProvider.notifier).loadNumericData();
     // 他の必要なViewModelの更新処理をここに追加
   }
 }

--- a/lib/core/services/data_refresh_service.dart
+++ b/lib/core/services/data_refresh_service.dart
@@ -15,7 +15,7 @@ class DataRefreshService extends StateNotifier<void> {
     // 他の必要なデータ更新処理をここに追加
   }
 
-  void onEnvironmentChanged(EnvironmentModel newEnvironment) async {
+  Future<void> onEnvironmentChanged(EnvironmentModel newEnvironment) async {
     // 環境設定が変更されたときの処理
     // Supabaseの再初期化などが必要な場合はここで行う
 

--- a/lib/core/services/supabase_service.dart
+++ b/lib/core/services/supabase_service.dart
@@ -38,7 +38,7 @@ class DataCache {
     var sensorData = _allData!.firstWhere((data) => data['public_id'] == sensorId, orElse: () => {});
     if (sensorData.isEmpty) return null;
 
-    var dataList = sensorData['DATA'] as List<dynamic>;
+    var dataList = sensorData['data'] as List<dynamic>;
     if (dataList.isEmpty) return null;
 
     var latestData = dataList.reduce((a, b) => DateTime.parse(a['created_at']).isAfter(DateTime.parse(b['created_at'])) ? a : b);
@@ -59,21 +59,21 @@ class RealSupabaseService implements SupabaseService {
   @override
   Future<void> fetchAllData() async {
     try {
-      final response = await _client.from('SENSOR').select('''
+      final response = await _client.from('sensor').select('''
           public_id,
           "group",
           name,
           data_type,
           created_at,
           updated_at,
-          DATA (
+          data (
             sensor_id,
             public_id,
             created_at,
             value,
             file_path
           )
-        ''').limit(10000, referencedTable: 'DATA');
+        ''').limit(10000, referencedTable: 'data');
       _cache.setAllData(response);
     } catch (e) {
       throw Exception('Error fetching all data: $e');
@@ -106,7 +106,7 @@ class MockSupabaseService implements SupabaseService {
         'data_type': sensor.dataType,
         'created_at': sensor.createdAt.toIso8601String(),
         'updated_at': sensor.updatedAt.toIso8601String(),
-        'DATA': sensorData
+        'data': sensorData
             .map((data) => {
                   'sensor_id': data.sensorId,
                   'public_id': data.publicId,

--- a/lib/core/services/supabase_service.dart
+++ b/lib/core/services/supabase_service.dart
@@ -53,8 +53,10 @@ abstract class SupabaseService {
 }
 
 class RealSupabaseService implements SupabaseService {
-  SupabaseClient get _client => Supabase.instance.client;
+  final SupabaseClient _client;
   final DataCache _cache = DataCache();
+
+  RealSupabaseService(this._client);
 
   @override
   Future<void> fetchAllData() async {
@@ -93,6 +95,7 @@ class RealSupabaseService implements SupabaseService {
 
 class MockSupabaseService implements SupabaseService {
   final DataCache _cache = DataCache();
+  int _counter = 0;
 
   @override
   Future<void> fetchAllData() async {
@@ -111,7 +114,7 @@ class MockSupabaseService implements SupabaseService {
                   'sensor_id': data.sensorId,
                   'public_id': data.publicId,
                   'created_at': data.createdAt?.toIso8601String(),
-                  'value': data.value,
+                  'value': data.value! + _counter,
                   'file_path': data.filePath,
                 })
             .toList(),

--- a/lib/core/widgets/number_data_list_item.dart
+++ b/lib/core/widgets/number_data_list_item.dart
@@ -3,22 +3,22 @@ import 'package:flutter/material.dart';
 import '../../data/models/numeric_data_model.dart';
 
 class NumericDataListItem extends StatelessWidget {
-  final NumericData numberData;
+  final NumericData numericData;
   final VoidCallback onTap;
 
   const NumericDataListItem({
     Key? key,
-    required this.numberData,
+    required this.numericData,
     required this.onTap,
   }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    final latestData = numberData.data.isNotEmpty ? numberData.data.last.value : 'N/A';
+    final latestData = numericData.data.isNotEmpty ? numericData.data.last.value : 'N/A';
 
     return ListTile(
-      title: Text('${numberData.group} - ${numberData.name}'),
-      subtitle: Text('Latest Value: $latestData ${numberData.dataType}'),
+      title: Text('${numericData.group} - ${numericData.name}'),
+      subtitle: Text('Latest Value: $latestData ${numericData.dataType}'),
       trailing: Icon(Icons.chevron_right),
       onTap: onTap,
     );

--- a/lib/features/environment/models/environment_model.dart
+++ b/lib/features/environment/models/environment_model.dart
@@ -1,34 +1,28 @@
+import 'package:uuid/uuid.dart';
+
 /// A model class representing an environment configuration.
 class EnvironmentModel {
-  /// The anonymous key used for authentication.
+  final String id;
   String? anonKey;
-
-  /// The URL of the Supabase instance.
   String? supabaseUrl;
-
-  /// The name of the environment.
   String? envName;
-
-  /// The password associated with the environment.
   String? password;
-
-  /// The email address associated with the environment.
   String? emailAddress;
-
-  /// Indicates whether this environment is selected as the primary environment.
   bool? selected;
 
   /// Constructor to create an instance of [EnvironmentModel].
   EnvironmentModel({
+    String? id,
     this.anonKey,
     this.supabaseUrl,
     this.envName,
     this.password,
     this.emailAddress,
     this.selected,
-  });
+  }) : id = id ?? Uuid().v4();
 
   EnvironmentModel copyWith({
+    String? id,
     String? anonKey,
     String? supabaseUrl,
     String? envName,
@@ -37,6 +31,7 @@ class EnvironmentModel {
     bool? selected,
   }) {
     return EnvironmentModel(
+      id: id ?? this.id,
       anonKey: anonKey ?? this.anonKey,
       supabaseUrl: supabaseUrl ?? this.supabaseUrl,
       envName: envName ?? this.envName,
@@ -47,10 +42,8 @@ class EnvironmentModel {
   }
 
   /// Converts an [EnvironmentModel] instance to a JSON map.
-  ///
-  /// This method is useful for saving the environment configuration
-  /// to a secure storage or sending it over the network.
   Map<String, dynamic> toJson() => {
+        'id': id,
         'anon_key': anonKey,
         'supabase_url': supabaseUrl,
         'env_name': envName,
@@ -60,10 +53,8 @@ class EnvironmentModel {
       };
 
   /// Creates an [EnvironmentModel] instance from a JSON map.
-  ///
-  /// This factory constructor is useful for creating an environment
-  /// configuration instance from data retrieved from secure storage or a network response.
   factory EnvironmentModel.fromJson(Map<String, dynamic> json) => EnvironmentModel(
+        id: json['id'],
         anonKey: json['anon_key'],
         supabaseUrl: json['supabase_url'],
         envName: json['env_name'],

--- a/lib/features/environment/models/environment_model.dart
+++ b/lib/features/environment/models/environment_model.dart
@@ -28,6 +28,24 @@ class EnvironmentModel {
     this.selected,
   });
 
+  EnvironmentModel copyWith({
+    String? anonKey,
+    String? supabaseUrl,
+    String? envName,
+    String? password,
+    String? emailAddress,
+    bool? selected,
+  }) {
+    return EnvironmentModel(
+      anonKey: anonKey ?? this.anonKey,
+      supabaseUrl: supabaseUrl ?? this.supabaseUrl,
+      envName: envName ?? this.envName,
+      password: password ?? this.password,
+      emailAddress: emailAddress ?? this.emailAddress,
+      selected: selected ?? this.selected,
+    );
+  }
+
   /// Converts an [EnvironmentModel] instance to a JSON map.
   ///
   /// This method is useful for saving the environment configuration

--- a/lib/features/environment/viewmodels/environment_viewmodel.dart
+++ b/lib/features/environment/viewmodels/environment_viewmodel.dart
@@ -1,6 +1,6 @@
 import 'dart:convert';
 
-import 'package:flutter/material.dart';
+import 'package:canaspad/core/services/app_state_service.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../core/services/secure_storage_service.dart';
@@ -8,33 +8,19 @@ import '../../../core/services/supabase_service.dart';
 import '../../../providers.dart';
 import '../models/environment_model.dart';
 
-class EnvironmentViewModel extends ChangeNotifier {
+class EnvironmentViewModel extends StateNotifier<List<EnvironmentModel>> {
   final SecureStorageService _secureStorageService;
   final SupabaseService _supabaseService;
-  List<EnvironmentModel> environments = [];
-  bool _disposed = false;
+  final Ref _ref;
 
-  EnvironmentViewModel(this._secureStorageService, this._supabaseService) {
+  EnvironmentViewModel(this._secureStorageService, this._supabaseService, this._ref) : super([]) {
     loadEnvironments();
   }
 
-  @override
-  void dispose() {
-    _disposed = true;
-    super.dispose();
-  }
-
-  @override
-  void notifyListeners() {
-    if (!_disposed) {
-      super.notifyListeners();
-    }
-  }
-
   Future<void> loadEnvironments() async {
-    environments = await _secureStorageService.readAllEnvironments();
-    _ensureOneSelectedEnvironment();
-    notifyListeners();
+    final environments = await _secureStorageService.readAllEnvironments();
+    _ensureOneSelectedEnvironment(environments);
+    state = environments;
   }
 
   void addEnvironment() {
@@ -42,42 +28,46 @@ class EnvironmentViewModel extends ChangeNotifier {
       envName: _generateEnvironmentName(),
       selected: false,
     );
-    environments.add(newEnvironment);
-    _ensureOneSelectedEnvironment();
+    state = [...state, newEnvironment];
+    _ensureOneSelectedEnvironment(state);
     _saveEnvironments();
   }
 
   Future<void> saveEnvironment(EnvironmentModel environment) async {
-    final index = environments.indexWhere((e) => e.envName == environment.envName);
+    final index = state.indexWhere((e) => e.envName == environment.envName);
+    List<EnvironmentModel> updatedEnvironments;
     if (index != -1) {
-      environments[index] = environment;
+      updatedEnvironments = [...state];
+      updatedEnvironments[index] = environment;
     } else {
-      environments.add(environment);
+      updatedEnvironments = [...state, environment];
     }
-    _ensureOneSelectedEnvironment();
+    _ensureOneSelectedEnvironment(updatedEnvironments);
+    state = updatedEnvironments;
     await _saveEnvironments();
 
-    // 環境が選択されている場合のみリフレッシュを行う
     if (environment.selected == true) {
-      await _refreshDataAfterEnvironmentChange();
+      await _refreshDataAfterEnvironmentChange(environment);
     }
   }
 
   Future<bool> deleteEnvironment(EnvironmentModel environment) async {
-    if (environments.length <= 1) {
+    if (state.length <= 1) {
       return false; // 最後の環境設定は削除できない
     }
 
     final wasSelected = environment.selected == true;
-    environments.remove(environment);
+    final updatedEnvironments = state.where((e) => e != environment).toList();
 
     if (wasSelected) {
-      // 選択されていた環境を削除した場合、別の環境を選択する
-      environments.first.selected = true;
-      await _saveEnvironments();
-      await _refreshDataAfterEnvironmentChange();
-    } else {
-      await _saveEnvironments();
+      updatedEnvironments.first.selected = true;
+    }
+
+    state = updatedEnvironments;
+    await _saveEnvironments();
+
+    if (wasSelected) {
+      await _refreshDataAfterEnvironmentChange(updatedEnvironments.first);
     }
 
     return true;
@@ -88,29 +78,26 @@ class EnvironmentViewModel extends ChangeNotifier {
       return; // 既に選択されている環境の選択を解除することはできない
     }
 
-    for (var env in environments) {
-      env.selected = (env == selectedEnvironment);
-    }
+    final updatedEnvironments = state.map((env) => env.copyWith(selected: env == selectedEnvironment)).toList();
+
+    state = updatedEnvironments;
     await _saveEnvironments();
-    // 選択された環境が変更された場合のみリフレッシュを行う
-    if (selectedEnvironment != environments.firstWhere((env) => env.selected == true)) {
-      await _refreshDataAfterEnvironmentChange();
-    }
+
+    // AppStateService を使用して環境を変更し、ログインを行う
+    await _ref.read(appStateServiceProvider.notifier).changeEnvironment(selectedEnvironment);
   }
 
-  void _ensureOneSelectedEnvironment() {
+  void _ensureOneSelectedEnvironment(List<EnvironmentModel> environments) {
     if (environments.isEmpty) {
       return;
     }
 
     final selectedEnvironments = environments.where((e) => e.selected == true).toList();
     if (selectedEnvironments.isEmpty) {
-      // 選択されている環境がない場合、最初の環境を選択する
       environments.first.selected = true;
     } else if (selectedEnvironments.length > 1) {
-      // 複数の環境が選択されている場合、最初の選択環境以外の選択を解除する
       for (var i = 1; i < selectedEnvironments.length; i++) {
-        selectedEnvironments[i].selected = false;
+        selectedEnvironments[i] = selectedEnvironments[i].copyWith(selected: false);
       }
     }
   }
@@ -118,30 +105,26 @@ class EnvironmentViewModel extends ChangeNotifier {
   Future<void> _saveEnvironments() async {
     await _secureStorageService.writeSecureData(
       'envSettings',
-      jsonEncode(environments.map((e) => e.toJson()).toList()),
+      jsonEncode(state.map((e) => e.toJson()).toList()),
     );
-    notifyListeners();
   }
 
   String _generateEnvironmentName() {
     int index = 1;
-    while (environments.any((env) => env.envName == 'Environment $index')) {
+    while (state.any((env) => env.envName == 'Environment $index')) {
       index++;
     }
     return 'Environment $index';
   }
 
-  Future<void> _refreshDataAfterEnvironmentChange() async {
-    if (_disposed) return;
-    // 環境設定が変更された後のデータ更新処理
+  Future<void> _refreshDataAfterEnvironmentChange(EnvironmentModel environment) async {
     await _supabaseService.fetchAllData();
-    // ここで他の必要なデータ更新処理を追加できます
-    notifyListeners();
+    await _ref.read(appStateServiceProvider.notifier).changeEnvironment(environment);
   }
 }
 
-final environmentViewModelProvider = ChangeNotifierProvider((ref) {
+final environmentViewModelProvider = StateNotifierProvider<EnvironmentViewModel, List<EnvironmentModel>>((ref) {
   final secureStorageService = ref.watch(secureStorageServiceProvider);
   final supabaseService = ref.watch(supabaseServiceProvider);
-  return EnvironmentViewModel(secureStorageService, supabaseService);
+  return EnvironmentViewModel(secureStorageService, supabaseService, ref);
 });

--- a/lib/features/environment/views/environment_detail_view.dart
+++ b/lib/features/environment/views/environment_detail_view.dart
@@ -25,12 +25,6 @@ class _EnvironmentDetailViewState extends ConsumerState<EnvironmentDetailView> {
     environment = widget.environment;
   }
 
-  @override
-  void dispose() {
-    // ここで必要なクリーンアップ処理を行う
-    super.dispose();
-  }
-
   Future<void> _saveEnvironment() async {
     if (_formKey.currentState!.validate()) {
       _formKey.currentState!.save();
@@ -109,28 +103,28 @@ class _EnvironmentDetailViewState extends ConsumerState<EnvironmentDetailView> {
                       key: Key('EnvironmentNameField'),
                       labelText: 'Environment Name',
                       initialValue: environment.envName,
-                      onSaved: (value) => environment.envName = value,
+                      onSaved: (value) => environment = environment.copyWith(envName: value),
                     ),
                     SizedBox(height: 16.0),
                     EnvironmentTextField(
                       key: Key('AnonKeyField'),
                       labelText: 'Anon Key',
                       initialValue: environment.anonKey,
-                      onSaved: (value) => environment.anonKey = value,
+                      onSaved: (value) => environment = environment.copyWith(anonKey: value),
                     ),
                     SizedBox(height: 16.0),
                     EnvironmentTextField(
                       key: Key('SupabaseUrlField'),
                       labelText: 'Supabase URL',
                       initialValue: environment.supabaseUrl,
-                      onSaved: (value) => environment.supabaseUrl = value,
+                      onSaved: (value) => environment = environment.copyWith(supabaseUrl: value),
                     ),
                     SizedBox(height: 16.0),
                     EnvironmentTextField(
                       key: Key('PasswordField'),
                       labelText: 'Password',
                       initialValue: environment.password,
-                      onSaved: (value) => environment.password = value,
+                      onSaved: (value) => environment = environment.copyWith(password: value),
                       obscureText: true,
                     ),
                     SizedBox(height: 16.0),
@@ -138,20 +132,18 @@ class _EnvironmentDetailViewState extends ConsumerState<EnvironmentDetailView> {
                       key: Key('EmailAddressField'),
                       labelText: 'Email Address',
                       initialValue: environment.emailAddress,
-                      onSaved: (value) => environment.emailAddress = value,
+                      onSaved: (value) => environment = environment.copyWith(emailAddress: value),
                     ),
                     SizedBox(height: 16.0),
                     SwitchListTile(
                       key: Key('SelectEnvironmentSwitch'),
                       title: Text('Select this environment'),
                       value: environment.selected ?? false,
-                      onChanged: environment.selected == true
-                          ? null
-                          : (value) {
-                              if (value) {
-                                ref.read(environmentViewModelProvider.notifier).selectEnvironment(environment);
-                              }
-                            },
+                      onChanged: (value) {
+                        setState(() {
+                          environment = environment.copyWith(selected: value);
+                        });
+                      },
                     ),
                     SizedBox(height: 16.0),
                     Row(

--- a/lib/features/environment/views/environment_view.dart
+++ b/lib/features/environment/views/environment_view.dart
@@ -1,13 +1,14 @@
+import 'package:canaspad/features/environment/viewmodels/environment_viewmodel.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../viewmodels/environment_viewmodel.dart';
 import 'environment_detail_view.dart';
 
 class EnvironmentView extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final viewModel = ref.watch(environmentViewModelProvider);
+    final environments = ref.watch(environmentViewModelProvider);
+    final viewModel = ref.read(environmentViewModelProvider.notifier);
 
     return Scaffold(
       appBar: AppBar(
@@ -16,9 +17,9 @@ class EnvironmentView extends ConsumerWidget {
       body: Padding(
         padding: const EdgeInsets.all(8.0),
         child: ListView.builder(
-          itemCount: viewModel.environments.length,
+          itemCount: environments.length,
           itemBuilder: (context, index) {
-            final env = viewModel.environments[index];
+            final env = environments[index];
             return Card(
               margin: const EdgeInsets.symmetric(vertical: 8.0),
               elevation: 4.0,

--- a/lib/features/environment/views/environment_view.dart
+++ b/lib/features/environment/views/environment_view.dart
@@ -31,18 +31,21 @@ class EnvironmentView extends ConsumerWidget {
                 title: Text(env.envName ?? 'No Name'),
                 subtitle: Text('Supabase URL: ${env.supabaseUrl ?? "N/A"}'),
                 trailing: Icon(Icons.arrow_forward_ios),
-                onTap: () async {
-                  final result = await Navigator.of(context).push(
+                onTap: () {
+                  Navigator.of(context)
+                      .push(
                     MaterialPageRoute(
                       builder: (context) => EnvironmentDetailView(
                         key: Key('EnvironmentDetailView'),
                         environment: env,
                       ),
                     ),
-                  );
-                  if (result == true) {
-                    viewModel.loadEnvironments();
-                  }
+                  )
+                      .then((value) {
+                    if (value == true) {
+                      viewModel.loadEnvironments();
+                    }
+                  });
                 },
               ),
             );

--- a/lib/features/home/home_view.dart
+++ b/lib/features/home/home_view.dart
@@ -15,7 +15,7 @@ class _HomeViewState extends State<HomeView> {
   int _selectedTabIndex = 0;
 
   static List<_TabItem> _tabItems = [
-    _TabItem(icon: Icons.trending_up, label: 'Numeric', view: NumberView(), key: Key('NumberTab')),
+    _TabItem(icon: Icons.trending_up, label: 'Numeric', view: NumericView(), key: Key('NumberTab')),
     _TabItem(icon: Icons.movie, label: 'Image', view: ImageView(), key: Key('ImageTab')),
     _TabItem(icon: Icons.notifications, label: 'Notification', view: NotificationView(), key: Key('NotificationTab')),
     _TabItem(icon: Icons.settings, label: 'Setting', view: SettingView(), key: Key('SettingTab')),

--- a/lib/features/initialization/viewmodels/initialization_viewmodel.dart
+++ b/lib/features/initialization/viewmodels/initialization_viewmodel.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 
 import 'package:canaspad/core/services/secure_storage_service.dart';
 import 'package:canaspad/core/services/supabase_service.dart';
+import 'package:canaspad/data/mock/environment_sample.dart';
 import 'package:canaspad/features/environment/models/environment_model.dart';
 import 'package:canaspad/providers.dart';
 import 'package:flutter/material.dart';
@@ -29,24 +30,7 @@ class InitializationViewModel extends ChangeNotifier {
   Future<void> _loadOrSaveSampleData() async {
     final environments = await _secureStorageService.readAllEnvironments();
     if (environments.isEmpty) {
-      final sampleData = [
-        EnvironmentModel(
-          anonKey: null,
-          supabaseUrl: null,
-          envName: "Environment 1",
-          password: null,
-          emailAddress: null,
-          selected: true,
-        ),
-        EnvironmentModel(
-          anonKey: null,
-          supabaseUrl: null,
-          envName: "Environment 2",
-          password: null,
-          emailAddress: null,
-          selected: false,
-        ),
-      ];
+      final sampleData = sampleEnvironmentData;
       await _secureStorageService.writeSecureData(
         'envSettings',
         jsonEncode(sampleData.map((e) => e.toJson()).toList()),

--- a/lib/features/initialization/viewmodels/initialization_viewmodel.dart
+++ b/lib/features/initialization/viewmodels/initialization_viewmodel.dart
@@ -21,6 +21,10 @@ class InitializationViewModel extends ChangeNotifier {
     await _fetchAllData();
   }
 
+  Future<EnvironmentModel?> getSelectedEnvironment() async {
+    return await _secureStorageService.readEnvironment();
+  }
+
   /// Saves sample environment data if no data exists in secure storage.
   Future<void> _loadOrSaveSampleData() async {
     final environments = await _secureStorageService.readAllEnvironments();

--- a/lib/features/initialization/views/initialization_view.dart
+++ b/lib/features/initialization/views/initialization_view.dart
@@ -1,75 +1,60 @@
+import 'package:canaspad/core/services/app_state_service.dart';
+import 'package:canaspad/features/home/home_view.dart';
+import 'package:canaspad/features/mini_game/game_main.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../../home/home_view.dart';
-import '../../mini_game/game_main.dart';
-import '../viewmodels/initialization_viewmodel.dart';
-
-class InitializationView extends ConsumerStatefulWidget {
+class InitializationView extends ConsumerWidget {
   final String flavor;
 
   InitializationView({required this.flavor});
 
   @override
-  _InitializationViewState createState() => _InitializationViewState();
-}
+  Widget build(BuildContext context, WidgetRef ref) {
+    final appState = ref.watch(appStateServiceProvider);
 
-class _InitializationViewState extends ConsumerState<InitializationView> {
-  late InitializationViewModel _viewModel;
-
-  @override
-  void initState() {
-    super.initState();
-    _viewModel = ref.read(initializationViewModelProvider);
-    _initializeApp();
-  }
-
-  Future<void> _initializeApp() async {
-    await _viewModel.initializeApp();
-    _checkNetworkAndLoadData();
-  }
-
-  Future<void> _checkNetworkAndLoadData() async {
-    final isConnected = await _viewModel.checkNetworkConnectivity();
-    if (isConnected) {
-      await Future.delayed(Duration(seconds: 3)); // Simulate a delay
-      Navigator.of(context).pushReplacement(MaterialPageRoute(builder: (context) => HomeView()));
-    } else {
-      _showNetworkError();
-    }
-  }
-
-  void _showNetworkError() {
-    showDialog(
-      context: context,
-      builder: (context) => AlertDialog(
-        title: Text('Network Error'),
-        content: Text('There is a problem with the network connection. Please check your connection.'),
-        actions: [
-          TextButton(
-            onPressed: () {
-              Navigator.of(context).pushReplacement(MaterialPageRoute(builder: (context) => MyGame()));
-            },
-            child: Text('Play Game'),
-          ),
-          TextButton(
-            onPressed: () {
-              Navigator.of(context).pop();
-              _checkNetworkAndLoadData(); // Retry
-            },
-            child: Text('Retry'),
-          ),
-        ],
+    return Scaffold(
+      body: Center(
+        child: appState.when(
+          loading: () => CircularProgressIndicator(),
+          error: (error, stack) => _buildErrorWidget(context, ref, error.toString()),
+          data: (environment) {
+            if (environment != null) {
+              // ログイン成功時、HomeViewに遷移
+              WidgetsBinding.instance.addPostFrameCallback((_) {
+                Navigator.of(context).pushReplacement(
+                  MaterialPageRoute(builder: (context) => HomeView()),
+                );
+              });
+              return CircularProgressIndicator();
+            } else {
+              // 環境設定がない場合の処理
+              return Text('No environment configured. Please set up the environment.');
+            }
+          },
+        ),
       ),
     );
   }
 
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      body: Center(
-        child: CircularProgressIndicator(),
-      ),
+  Widget _buildErrorWidget(BuildContext context, WidgetRef ref, String error) {
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        Text('Error: $error'),
+        ElevatedButton(
+          onPressed: () => ref.read(appStateServiceProvider.notifier).initializeApp(),
+          child: Text('Retry'),
+        ),
+        ElevatedButton(
+          onPressed: () {
+            Navigator.of(context).pushReplacement(
+              MaterialPageRoute(builder: (context) => MyGame()),
+            );
+          },
+          child: Text('Play Game'),
+        ),
+      ],
     );
   }
 }

--- a/lib/features/initialization/views/initialization_view.dart
+++ b/lib/features/initialization/views/initialization_view.dart
@@ -1,5 +1,6 @@
 import 'package:canaspad/core/services/app_state_service.dart';
 import 'package:canaspad/features/home/home_view.dart';
+import 'package:canaspad/features/initialization/viewmodels/initialization_viewmodel.dart';
 import 'package:canaspad/features/mini_game/game_main.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -11,6 +12,7 @@ class InitializationView extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    ref.read(initializationViewModelProvider).initializeApp();
     final appState = ref.watch(appStateServiceProvider);
 
     return Scaffold(

--- a/lib/features/number/viewmodels/number_data_state.dart
+++ b/lib/features/number/viewmodels/number_data_state.dart
@@ -36,15 +36,15 @@ class NumericDataViewModel extends StateNotifier<NumericDataState> {
   Future<void> loadNumericData() async {
     try {
       state = state.copyWith(isLoading: true, error: null);
-      final numberData = await _supabaseService.getNumericData();
-      state = state.copyWith(data: numberData, isLoading: false);
+      final numericData = await _supabaseService.getNumericData();
+      state = state.copyWith(data: numericData, isLoading: false);
     } catch (e) {
       state = state.copyWith(error: e.toString(), isLoading: false);
     }
   }
 }
 
-final numberDataViewModelProvider = StateNotifierProvider<NumericDataViewModel, NumericDataState>((ref) {
+final numericDataViewModelProvider = StateNotifierProvider<NumericDataViewModel, NumericDataState>((ref) {
   final supabaseService = ref.watch(supabaseServiceProvider);
   return NumericDataViewModel(supabaseService);
 });

--- a/lib/features/number/viewmodels/number_viewmodel.dart
+++ b/lib/features/number/viewmodels/number_viewmodel.dart
@@ -36,15 +36,15 @@ class NumericDataViewModel extends StateNotifier<NumericDataState> {
   Future<void> loadNumericData() async {
     try {
       state = state.copyWith(isLoading: true, error: null);
-      final numberData = await _supabaseService.getNumericData();
-      state = state.copyWith(data: numberData, isLoading: false);
+      final numericData = await _supabaseService.getNumericData();
+      state = state.copyWith(data: numericData, isLoading: false);
     } catch (e) {
       state = state.copyWith(error: e.toString(), isLoading: false);
     }
   }
 }
 
-final numberDataViewModelProvider = StateNotifierProvider<NumericDataViewModel, NumericDataState>((ref) {
+final numericDataViewModelProvider = StateNotifierProvider<NumericDataViewModel, NumericDataState>((ref) {
   final supabaseService = ref.watch(supabaseServiceProvider);
   return NumericDataViewModel(supabaseService);
 });

--- a/lib/features/number/views/number_detail_view.dart
+++ b/lib/features/number/views/number_detail_view.dart
@@ -5,21 +5,21 @@ import '../../../data/models/data_model.dart';
 import '../../../data/models/numeric_data_model.dart';
 
 class NumberDetailView extends StatelessWidget {
-  final NumericData numberData;
+  final NumericData numericData;
 
-  NumberDetailView({required this.numberData});
+  NumberDetailView({required this.numericData});
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text('${numberData.group} - ${numberData.name}'),
+        title: Text('${numericData.group} - ${numericData.name}'),
       ),
       body: Column(
         children: [
-          Text('Sensor: ${numberData.name}'),
-          Text('Group: ${numberData.group}'),
-          Text('Data Type: ${numberData.dataType}'),
+          Text('Sensor: ${numericData.name}'),
+          Text('Group: ${numericData.group}'),
+          Text('Data Type: ${numericData.dataType}'),
           Expanded(
             child: SfCartesianChart(
               primaryXAxis: DateTimeAxis(
@@ -30,7 +30,7 @@ class NumberDetailView extends StatelessWidget {
               ),
               series: <CartesianSeries>[
                 LineSeries<Data, DateTime>(
-                  dataSource: numberData.data,
+                  dataSource: numericData.data,
                   xValueMapper: (Data data, _) => data.createdAt,
                   yValueMapper: (Data data, _) => data.value,
                 )

--- a/lib/features/number/views/number_view.dart
+++ b/lib/features/number/views/number_view.dart
@@ -5,12 +5,12 @@ import '../../../core/widgets/number_data_list_item.dart';
 import '../viewmodels/number_data_state.dart';
 import 'number_detail_view.dart';
 
-class NumberView extends ConsumerStatefulWidget {
+class NumericView extends ConsumerStatefulWidget {
   @override
-  _NumberViewState createState() => _NumberViewState();
+  _NumericViewState createState() => _NumericViewState();
 }
 
-class _NumberViewState extends ConsumerState<NumberView> {
+class _NumericViewState extends ConsumerState<NumericView> {
   @override
   void initState() {
     super.initState();
@@ -25,7 +25,7 @@ class _NumberViewState extends ConsumerState<NumberView> {
 
     return Scaffold(
       appBar: AppBar(
-        title: Text('Number View'),
+        title: Text('Numeric View'),
       ),
       body: _buildBody(context, state),
     );

--- a/lib/features/number/views/number_view.dart
+++ b/lib/features/number/views/number_view.dart
@@ -15,13 +15,13 @@ class _NumberViewState extends ConsumerState<NumberView> {
   void initState() {
     super.initState();
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      ref.read(numberDataViewModelProvider.notifier).loadNumericData();
+      ref.read(numericDataViewModelProvider.notifier).loadNumericData();
     });
   }
 
   @override
   Widget build(BuildContext context) {
-    final state = ref.watch(numberDataViewModelProvider);
+    final state = ref.watch(numericDataViewModelProvider);
 
     return Scaffold(
       appBar: AppBar(
@@ -42,13 +42,13 @@ class _NumberViewState extends ConsumerState<NumberView> {
       return ListView.builder(
         itemCount: state.data.length,
         itemBuilder: (context, index) {
-          final numberData = state.data[index];
+          final numericData = state.data[index];
           return NumericDataListItem(
-            numberData: numberData,
+            numericData: numericData,
             onTap: () => Navigator.push(
               context,
               MaterialPageRoute(
-                builder: (context) => NumberDetailView(numberData: numberData),
+                builder: (context) => NumberDetailView(numericData: numericData),
               ),
             ),
           );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -17,7 +17,6 @@ Future<void> initializeApp() async {
   final flavor = const String.fromEnvironment('FLAVOR', defaultValue: 'production');
   EnvironmentModel? selectedEnvironment;
 
-  // フレーバーに応じてプロバイダーを上書き
   final overrides = [
     flavorProvider.overrideWithProvider(StateProvider((ref) => flavor)),
   ];
@@ -29,11 +28,6 @@ Future<void> initializeApp() async {
       await Supabase.initialize(
         url: selectedEnvironment.supabaseUrl ?? 'YOUR_DEFAULT_SUPABASE_URL',
         anonKey: selectedEnvironment.anonKey ?? 'YOUR_DEFAULT_SUPABASE_ANON_KEY',
-      );
-    } else {
-      await Supabase.initialize(
-        url: 'YOUR_DEFAULT_SUPABASE_URL',
-        anonKey: 'YOUR_DEFAULT_SUPABASE_ANON_KEY',
       );
     }
     if (selectedEnvironment != null) {

--- a/lib/providers.dart
+++ b/lib/providers.dart
@@ -1,5 +1,6 @@
 // lib/providers.dart
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
 
 import 'core/services/auth_service.dart';
 import 'core/services/secure_storage_service.dart';
@@ -20,7 +21,8 @@ final supabaseServiceProvider = Provider<SupabaseService>((ref) {
   if (flavor == 'develop') {
     return MockSupabaseService();
   } else {
-    return RealSupabaseService();
+    final client = Supabase.instance.client;
+    return RealSupabaseService(client);
   }
 });
 


### PR DESCRIPTION
このプルリクエストでは、アプリの状態管理を一元化し、環境設定の変更に柔軟に対応できるよう、AppStateService を導入しました。これにより、ログイン状態、選択された環境、データの読み込み状態などを一箇所で管理できるようになり、コードの可読性、保守性、そして拡張性が向上しました。

## 変更の動機と背景

従来のアプリでは、ログイン状態や選択された環境に関する情報が複数の ViewModel に分散しており、状態管理が複雑化していました。この分散化された状態管理は、以下の問題を引き起こしていました。

1. **状態の不整合:** 複数の ViewModel がそれぞれ状態を保持するため、状態の同期が難しく、不整合が発生する可能性がありました。
2. **コードの重複:** 各 ViewModel で状態の更新ロジックが重複し、コードの冗長化と保守性の低下につながっていました。
3. **環境設定変更時の処理の煩雑さ:** 環境設定の変更に伴い、複数の ViewModel の状態を更新し、Supabase クライアントを再初期化する必要があり、処理が煩雑でした。

これらの問題を解決するために、アプリの状態を集中管理する `AppStateService` を導入しました。

## 変更点

### 1. AppStateService の導入

アプリ全体のログイン状態、選択された環境、データの読み込み状態などを集中管理する `AppStateService` を追加しました。

**コード例: AppStateService の使用**

```dart
// NumberViewModel 内
final appState = ref.watch(appStateServiceProvider);
final currentEnvironment = appState.data?.value;
```

### 2. 環境設定変更時の処理の一元化

`DataRefreshService` を導入し、環境設定の変更に伴う処理（データのリフレッシュ、Supabase クライアントの再初期化など）を一元化しました。

**コード例: DataRefreshService の使用**

```dart
// EnvironmentViewModel 内
await ref.read(dataRefreshServiceProvider.notifier).onEnvironmentChanged(environment);
```

### 3. EnvironmentViewModel の状態管理の変更

`EnvironmentViewModel` の状態管理を `ChangeNotifier` から `StateNotifier` に変更し、環境設定リストを状態として管理するようにしました。これにより、状態管理のロジックが簡素化され、コードの可読性が向上しました。

### 4. EnvironmentModel への id プロパティ追加

`EnvironmentModel` に `id` プロパティを追加することで、各環境設定を一意に識別できるようにしました。


## メリット

- **状態管理の一貫性と簡素化:** アプリの状態を一元管理することで、コードの重複を減らし、状態管理の一貫性を向上させました。
- **環境設定変更への柔軟な対応:** 環境設定の変更が検知され、自動的にデータの再取得と UI の更新が行われるため、ユーザーエクスペリエンスが向上しました。
- **コードの可読性と保守性の向上:** 処理の集約と状態管理の明確化により、コードの可読性と保守性が向上しました。